### PR TITLE
several improvements sectxt parser and validator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,248 @@
-__pycache__
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
 dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
 *.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### PyCharm Patch ###
+# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
+
+# Sonarlint plugin
+# https://plugins.jetbrains.com/plugin/7973-sonarlint
+.idea/**/sonarlint/
+
+# SonarQube Plugin
+# https://plugins.jetbrains.com/plugin/7238-sonarqube-community-plugin
+.idea/**/sonarIssues.xml
+
+# Markdown Navigator plugin
+# https://plugins.jetbrains.com/plugin/7896-markdown-navigator-enhanced
+.idea/**/markdown-navigator.xml
+.idea/**/markdown-navigator-enh.xml
+.idea/**/markdown-navigator/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This package contains a security.txt ([RFC 9116](https://www.rfc-editor.org/info/rfc9116)) parser and validator.
 
-The main purpose of security.txt is to help make things easier for companies and security researchers when trying to secure platforms. Thanks to security.txt, security researchers can easily get in touch with companies about security issues.
+When security risks in web services are discovered by independent security researchers who understand the severity of the risk, they often lack the channels to disclose them properly. As a result, security issues may be left unreported. security.txt defines a standard to help organizations define the process for security researchers to disclose security vulnerabilities securely.
 
 ## Installation
 
@@ -46,31 +46,32 @@ a dict with three keys:
 
 ### Possible errors
 
-| code                 | message                                                                                                                 |
-|----------------------|-------------------------------------------------------------------------------------------------------------------------|
-| "no_security_txt"    | "security.txt could not be located."                                                                                    |
-| "location"           | "security.txt was located on the top-level path (legacy place), but must be placed under the '/.well-known/' path."     |
-| "invalid_uri_scheme" | "Insecure URI scheme HTTP is not allowed. The security.txt file access MUST use the \"https\" scheme"                   |
-| "invalid_cert"       | "security.txt must be served with a valid TLS certificate."                                                             |
-| "no_content_type"    | "HTTP Content-Type header must be sent."                                                                                |
-| "invalid_media"      | "Media type in Content-Type header must be 'text/plain'."                                                               |
-| "invalid_charset"    | "Charset parameter in Content-Type header must be 'utf-8' if present."                                                  |
-| "utf8"               | "Content must be utf-8 encoded."                                                                                        |
-| "no_expire"          | "'Expires' field must be present."                                                                                      |
-| "multi_expire"       | "'Expires' field must not appear more than once."                                                                       |
-| "invalid_expiry"     | "Date and time in 'Expires' field must be formatted according to ISO 8601."                                             | 
-| "expired"            | "Date and time in 'Expires' field must not be in the past."                                                             |
-| "no_contact"         | "'Contact' field must appear at least once."                                                                            |
+| code                 | message                                                                                                                                                                |
+|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| "no_security_txt"    | "security.txt could not be located."                                                                                                                                   |
+| "location"           | "security.txt was located on the top-level path (legacy place), but must be placed under the '/.well-known/' path."                                                    |
+| "invalid_uri_scheme" | "Insecure URI scheme HTTP is not allowed. The security.txt file access must use the 'https' scheme"                                                                    |
+| "invalid_cert"       | "security.txt must be served with a valid TLS certificate."                                                                                                            |
+| "no_content_type"    | "HTTP Content-Type header must be sent."                                                                                                                               |
+| "invalid_media"      | "Media type in Content-Type header must be 'text/plain'."                                                                                                              |
+| "invalid_charset"    | "Charset parameter in Content-Type header must be 'utf-8' if present."                                                                                                 |
+| "utf8"               | "Content must be utf-8 encoded."                                                                                                                                       |
+| "no_expire"          | "'Expires' field must be present."                                                                                                                                     |
+| "multi_expire"       | "'Expires' field must not appear more than once."                                                                                                                      |
+| "invalid_expiry"     | "Date and time in 'Expires' field must be formatted according to ISO 8601."                                                                                            | 
+| "expired"            | "Date and time in 'Expires' field must not be in the past."                                                                                                            |
+| "no_contact"         | "'Contact' field must appear at least once."                                                                                                                           |
 | "no_canonical_match" | "Web URI where security.txt is located must match with a 'Canonical' field. In case of redirecting either the first or last web URI of the redirect chain must match." |
-| "multi_lang"         | "'Preferred-Languages' field must not appear more than once."                                                           |
-| "invalid_lang"       | "Value in 'Preferred-Languages' field must match one or more language tags as defined in RFC5646, separated by commas." |
-| "no_uri"             | "Field value must be a URI (e.g. beginning with 'mailto:')."                                                            |
-| "no_https"           | "Web URI must begin with 'https://'."                                                                                   |
-| "prec_ws"            | "There must be no whitespace before the field separator (colon)."                                                       |
-| "no_space"           | "Field separator (colon) must be followed by a space."                                                                  | 
-| "empty_key"          | "Field name must not be empty."                                                                                         |
-| "empty_value"        | "Field value must not be empty."                                                                                        |
-| "invalid_line"       | "Line must contain a field name and value, unless the line is blank or contains a comment."                             |
+| "multi_lang"         | "'Preferred-Languages' field must not appear more than once."                                                                                                          |
+| "invalid_lang"       | "Value in 'Preferred-Languages' field must match one or more language tags as defined in RFC5646, separated by commas."                                                |
+| "no_uri"             | "Field value must be a URI (e.g. beginning with 'mailto:')."                                                                                                           |
+| "no_https"           | "Web URI must begin with 'https://'."                                                                                                                                  |
+| "prec_ws"            | "There must be no whitespace before the field separator (colon)."                                                                                                      |
+| "no_space"           | "Field separator (colon) must be followed by a space."                                                                                                                 | 
+| "empty_key"          | "Field name must not be empty."                                                                                                                                        |
+| "empty_value"        | "Field value must not be empty."                                                                                                                                       |
+| "invalid_line"       | "Line must contain a field name and value, unless the line is blank or contains a comment."                                                                            |
+| "no_line_separators" | "Every line must end with either a carriage return and line feed characters or just a line feed character"                                                             |
 
 ### Possible recommendations
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # SecTXT: Security.txt parser and validator
 
-This package contains a security.txt (RFC 9116) parser and validator.
+This package contains a security.txt ([RFC 9116](https://www.rfc-editor.org/info/rfc9116)) parser and validator.
+
+The main purpose of security.txt is to help make things easier for companies and security researchers when trying to secure platforms. Thanks to security.txt, security researchers can easily get in touch with companies about security issues.
 
 ## Installation
 
@@ -48,6 +50,7 @@ a dict with three keys:
 |----------------------|-------------------------------------------------------------------------------------------------------------------------|
 | "no_security_txt"    | "security.txt could not be located."                                                                                    |
 | "location"           | "security.txt was located on the top-level path (legacy place), but must be placed under the '/.well-known/' path."     |
+| "invalid_uri_scheme" | "Insecure URI scheme HTTP is not allowed. The security.txt file access MUST use the \"https\" scheme"                   |
 | "invalid_cert"       | "security.txt must be served with a valid TLS certificate."                                                             |
 | "no_content_type"    | "HTTP Content-Type header must be sent."                                                                                |
 | "invalid_media"      | "Media type in Content-Type header must be 'text/plain'."                                                               |
@@ -71,22 +74,24 @@ a dict with three keys:
 
 ### Possible recommendations
 
-| code             | message                                                                                                  |
-|------------------|----------------------------------------------------------------------------------------------------------|
-| "long_expiry"    | "Date and time in 'Expires' field should be less than a year into the future."                           |
-| "no_encryption"  | "'Encryption' field should be present when 'Contact' field contains an email address."                   |
-| "not_signed"     | "security.txt should be digitally signed."                                                               |
-| "no_canonical"   | "'Canonical' field should be present in a signed file."                                                  |
+| code                       | message                                                                                                  |
+|----------------------------|----------------------------------------------------------------------------------------------------------|
+| "long_expiry"              | "Date and time in 'Expires' field should be less than a year into the future."                           |
+| "no_encryption"            | "'Encryption' field should be present when 'Contact' field contains an email address."                   |
+| "not_signed"<sup>[1]</sup> | "security.txt should be digitally signed."                                                               |
+| "no_canonical"             | "'Canonical' field should be present in a signed file."                                                  |
 
 ### Possible notifications
 
-| code             | message                                                                                                  |
-|------------------|----------------------------------------------------------------------------------------------------------|
-| "unknown_field"<sup>[1]</sup>  | "security.txt contains an unknown field. Either this is a custom field which may not be widely supported, or there is a typo in a standardised field name." |
+| code                          | message                                                                                                  |
+|-------------------------------|----------------------------------------------------------------------------------------------------------|
+| "unknown_field"<sup>[2]</sup> | "security.txt contains an unknown field. Either this is a custom field which may not be widely supported, or there is a typo in a standardised field name." |
 
 ---
 
-[1] Regarding code "unknown_field": According to RFC 9116 section 2.4, any fields that are not explicitly supported should be ignored. This parser does add a notification for unknown fields by default. This behaviour can be turned off using the parameter recommend_unknown_fields:
+[1] The security.txt parser will check for the addition of the digital signature, but it will not verify the validity of the signature.
+
+[2] Regarding code "unknown_field": According to RFC 9116 section 2.4, any fields that are not explicitly supported should be ignored. This parser does add a notification for unknown fields by default. This behaviour can be turned off using the parameter recommend_unknown_fields:
 ```python
 
 >>> from sectxt import SecurityTXT

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ a dict with three keys:
 |----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | "no_security_txt"    | "security.txt could not be located."                                                                                                                                   |
 | "location"           | "security.txt was located on the top-level path (legacy place), but must be placed under the '/.well-known/' path."                                                    |
-| "invalid_uri_scheme" | "Insecure URI scheme HTTP is not allowed. The security.txt file access must use the 'https' scheme"                                                                    |
+| "invalid_uri_scheme" | "Insecure URI scheme HTTP is not allowed. The security.txt file access must use the HTTPS scheme"                                                                      |
 | "invalid_cert"       | "security.txt must be served with a valid TLS certificate."                                                                                                            |
 | "no_content_type"    | "HTTP Content-Type header must be sent."                                                                                                                               |
 | "invalid_media"      | "Media type in Content-Type header must be 'text/plain'."                                                                                                              |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests
 python-dateutil
 langcodes
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 python-dateutil
 langcodes
 pytest
+requests-mock

--- a/sectxt/__init__.py
+++ b/sectxt/__init__.py
@@ -83,8 +83,6 @@ class Parser:
             self._line_info.append(self._parse_line(line))
             self._line_no += 1
         self._line_no = None
-        if self._line_info and self._line_info[-1]["type"] == "empty":
-            del self._line_info[-1]
         self.validate_contents()
 
     def _add_error(
@@ -256,7 +254,7 @@ class Parser:
                     "Web URI where security.txt is located must match with a "
                     "'Canonical' field. In case of redirecting either the "
                     "first or last web URI of the redirect chain must match.")
-        if len(self.lines) == 1:
+        if self.lines[-1]["type"] != 'empty':
             self._add_error("no_line_separators",
                             "Every line must end with either a carriage "
                             "return and line feed characters or just a line "


### PR DESCRIPTION
This pull request will resolve the following open issues on the sectxt repo.
- Note that does not verify the signature #34 
- Check for Line Separator? #21 
- What message when security.txt file is NOT available via https? #24 

The changes also includes
- more detailed gitignore
- pytest and request mock in the requirements
- more tests, some including not just the parser but also the initial domain checks

In regards to issue #34: I agree that there might be some misconception since it is a validator of security.txt. A index is added to the signature recommendation which clarifies this.
In regards to issue #21: The RFC does specify that every line MUST end using a line feed. An error for this is added, which checks if the final line is an empty line. If this is not the case not all lines end with a line feed.
In regards to issue: #24: In the event that the security.txt is hosted but not on https it would give an error that it could not find it. This might cause confusion, since the file is hosted. An additional check is added which checks the insecure URI scheme. If the security.txt is found than an error is added which clarifies that the scheme is not correct and the https scheme should be used.