### PR TITLE
Fixes #51 lowercase security.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SecTXT: Security.txt parser and validator
+# SecTXT: security.txt parser and validator
 
 This package contains a security.txt ([RFC 9116](https://www.rfc-editor.org/info/rfc9116)) parser and validator.
 
@@ -91,7 +91,7 @@ a dict with three keys:
 
 | code                          | message                                                                                                                                                                     |
 |-------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| "unknown_field"<sup>[2]</sup> | "Security.txt contains an unknown field. Field {unknown_field} is either a custom field which may not be widely supported, or there is a typo in a standardised field name. |
+| "unknown_field"<sup>[2]</sup> | "security.txt contains an unknown field. Field {unknown_field} is either a custom field which may not be widely supported, or there is a typo in a standardised field name. |
 
 
 ---

--- a/sectxt/__init__.py
+++ b/sectxt/__init__.py
@@ -221,7 +221,7 @@ class Parser:
         if self.recommend_unknown_fields and key not in self.known_fields:
             self._add_notification(
                 "unknown_field",
-                "Security.txt contains an unknown field. "
+                "security.txt contains an unknown field. "
                 'Field "%s" is either a custom field which may not be widely '
                 "supported, or there is a typo in a standardised field name." % key,
             )


### PR DESCRIPTION
```bash
grep -Rl 'Security.txt' | xargs sed -i 's/Security.txt/security.txt/g'
```