### PR TITLE
Add error message byte order mark

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ a dict with three keys:
 | "no_csaf_file"        | "All CSAF fields must point to a provider-metadata.json file."                                                                                                         |
 | "pgp_data_error"      | "Signed message did not contain a correct ASCII-armored PGP block."                                                                                                    |
 | "pgp_error"           | "Decoding or parsing of the pgp message failed."                                                                                                                       |
+| "bom_in_file"         | "The Byte-Order Mark was found in the UTF-8 File. Security.txt must be encoded using UTF-8 in Net-Unicode form, the BOM signature must not appear at the beginning."   |
 
 
 ### Possible recommendations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.31.0
 python-dateutil==2.8.2
 langcodes==3.3.0
-pytest==7.4.0
+pytest==7.4.3
 requests-mock==1.11.0
 PGPy==0.6.0

--- a/sectxt/__init__.py
+++ b/sectxt/__init__.py
@@ -103,8 +103,10 @@ class Parser:
         explicit_line_no=None
     ) -> None:
         if explicit_line_no:
-            self._line_no = explicit_line_no
-        err_dict: ErrorDict = {"code": code, "message": message, "line": self._line_no}
+            error_line = explicit_line_no
+        else:
+            error_line = self._line_no
+        err_dict: ErrorDict = {"code": code, "message": message, "line": error_line}
         self._errors.append(err_dict)
 
     def _add_recommendation(
@@ -418,6 +420,12 @@ class SecurityTXT(Parser):
         try:
             if content.startswith(codecs.BOM_UTF8):
                 content = content.replace(codecs.BOM_UTF8, b'')
+            self._add_error(
+                "bom_in_file",
+                "The Byte-Order Mark was found in the UTF-8 File. "
+                "Security.txt must be encoded using UTF-8 in Net-Unicode form, "
+                "the BOM signature must not appear at the beginning."
+            )
             return content.decode('utf-8')
         except UnicodeError:
             self._add_error("utf8", "Content must be utf-8 encoded.")

--- a/test/test_sectxt.py
+++ b/test/test_sectxt.py
@@ -292,8 +292,9 @@ def test_invalid_uri_scheme(requests_mock: Mocker):
 
 def test_byte_order_mark(requests_mock: Mocker):
     with Mocker() as m:
+        expires = f"Expires: {(date.today() + timedelta(days=10)).isoformat()}T18:37:07z\n"
         byte_content_with_bom = b'\xef\xbb\xbf\xef\xbb\xbfContact: mailto:me@example.com\n' \
-                                b'Expires: 2023-08-11T18:37:07z\n'
+                                + bytes(expires, "utf-8")
         m.get(
             "https://example.com/.well-known/security.txt",
             headers={"content-type": "text/plain"},

--- a/test/test_sectxt.py
+++ b/test/test_sectxt.py
@@ -301,4 +301,6 @@ def test_byte_order_mark(requests_mock: Mocker):
             content=byte_content_with_bom,
         )
         s = SecurityTXT("example.com")
-        assert(s.is_valid())
+        assert(not s.is_valid())
+        if not any(d["code"] == "bom_in_file" for d in s.errors):
+            pytest.fail("bom_in_file error code should be given")


### PR DESCRIPTION
For issue #57 an error message has been added. If the byte order mark is present in the file it will continue to process the file without the BOM, but it will add an error to highlight that the file has the BOM present.
For issue #60 we fixed the issue that it would override the line_no. Now it will never override the line number in the add_error function.