### PR TITLE
sectxt update 0.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,38 +46,38 @@ a dict with three keys:
 
 ### Possible errors
 
-| code                  | message                                                                                                                                                                |
-|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| "no_security_txt"     | "security.txt could not be located."                                                                                                                                   |
-| "location"            | "security.txt was located on the top-level path (legacy place), but must be placed under the '/.well-known/' path."                                                    |
-| "invalid_uri_scheme"  | "Insecure URI scheme HTTP is not allowed. The security.txt file access must use the HTTPS scheme"                                                                      |
-| "invalid_cert"        | "security.txt must be served with a valid TLS certificate."                                                                                                            |
-| "no_content_type"     | "HTTP Content-Type header must be sent."                                                                                                                               |
-| "invalid_media"       | "Media type in Content-Type header must be 'text/plain'."                                                                                                              |
-| "invalid_charset"     | "Charset parameter in Content-Type header must be 'utf-8' if present."                                                                                                 |
-| "utf8"                | "Content must be utf-8 encoded."                                                                                                                                       |
-| "no_expire"           | "'Expires' field must be present."                                                                                                                                     |
-| "multi_expire"        | "'Expires' field must not appear more than once."                                                                                                                      |
-| "invalid_expiry"      | "Date and time in 'Expires' field must be formatted according to ISO 8601."                                                                                            | 
-| "expired"             | "Date and time in 'Expires' field must not be in the past."                                                                                                            |
-| "no_contact"          | "'Contact' field must appear at least once."                                                                                                                           |
-| "no_canonical_match"  | "Web URI where security.txt is located must match with a 'Canonical' field. In case of redirecting either the first or last web URI of the redirect chain must match." |
-| "multi_lang"          | "'Preferred-Languages' field must not appear more than once."                                                                                                          |
-| "invalid_lang"        | "Value in 'Preferred-Languages' field must match one or more language tags as defined in RFC5646, separated by commas."                                                |
-| "no_uri"              | "Field '{field}' value must be a URI."                                                                                                                                 |
-| "no_https"            | "Web URI must begin with 'https://'."                                                                                                                                  |
-| "prec_ws"             | "There must be no whitespace before the field separator (colon)."                                                                                                      |
-| "no_space"            | "Field separator (colon) must be followed by a space."                                                                                                                 | 
-| "empty_key"           | "Field name must not be empty."                                                                                                                                        |
-| "empty_value"         | "Field value must not be empty."                                                                                                                                       |
-| "invalid_line"        | "Line must contain a field name and value, unless the line is blank or contains a comment."                                                                            |
-| "no_line_separators"  | "Every line, including the last one, must end with either a carriage return and line feed characters or just a line feed character"                                    |
-| "signed_format_issue" | "Signed security.txt must start with the header '-----BEGIN PGP SIGNED MESSAGE-----'. "                                                                                |
-| "data_after_sig"      | "Signed security.txt must not contain data after the signature."                                                                                                       |
-| "no_csaf_file"        | "All CSAF fields must point to a provider-metadata.json file."                                                                                                         |
-| "pgp_data_error"      | "Signed message did not contain a correct ASCII-armored PGP block."                                                                                                    |
-| "pgp_error"           | "Decoding or parsing of the pgp message failed."                                                                                                                       |
-| "bom_in_file"         | "The Byte-Order Mark was found in the UTF-8 File. Security.txt must be encoded using UTF-8 in Net-Unicode form, the BOM signature must not appear at the beginning."   |
+| code                  | message                                                                                                                                                                     |
+|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| "no_security_txt"     | "security.txt could not be located."                                                                                                                                        |
+| "location"            | "security.txt was located on the top-level path (legacy place), but must be placed under the '/.well-known/' path."                                                         |
+| "invalid_uri_scheme"  | "Insecure URI scheme HTTP is not allowed. The security.txt file access must use the HTTPS scheme"                                                                           |
+| "invalid_cert"        | "security.txt must be served with a valid TLS certificate."                                                                                                                 |
+| "no_content_type"     | "HTTP Content-Type header must be sent."                                                                                                                                    |
+| "invalid_media"       | "Media type in Content-Type header must be 'text/plain'."                                                                                                                   |
+| "invalid_charset"     | "Charset parameter in Content-Type header must be 'utf-8' if present."                                                                                                      |
+| "utf8"                | "Content must be utf-8 encoded."                                                                                                                                            |
+| "no_expire"           | "'Expires' field must be present."                                                                                                                                          |
+| "multi_expire"        | "'Expires' field must not appear more than once."                                                                                                                           |
+| "invalid_expiry"      | "Date and time in 'Expires' field must be formatted according to ISO 8601."                                                                                                 | 
+| "expired"             | "Date and time in 'Expires' field must not be in the past."                                                                                                                 |
+| "no_contact"          | "'Contact' field must appear at least once."                                                                                                                                |
+| "no_canonical_match"  | "Web URI where security.txt is located must match with a 'Canonical' field. In case of redirecting either the first or last web URI of the redirect chain must match."      |
+| "multi_lang"          | "'Preferred-Languages' field must not appear more than once."                                                                                                               |
+| "invalid_lang"        | "Value in 'Preferred-Languages' field must match one or more language tags as defined in RFC5646, separated by commas."                                                     |
+| "no_uri"              | "Field '{field}' value must be a URI."                                                                                                                                      |
+| "no_https"            | "Web URI must begin with 'https://'."                                                                                                                                       |
+| "prec_ws"             | "There must be no whitespace before the field separator (colon)."                                                                                                           |
+| "no_space"            | "Field separator (colon) must be followed by a space."                                                                                                                      | 
+| "empty_key"           | "Field name must not be empty."                                                                                                                                             |
+| "empty_value"         | "Field value must not be empty."                                                                                                                                            |
+| "invalid_line"        | "Line must contain a field name and value, unless the line is blank or contains a comment."                                                                                 |
+| "no_line_separators"  | "Every line, including the last one, must end with either a carriage return and line feed characters or just a line feed character"                                         |
+| "signed_format_issue" | "Signed security.txt must start with the header '-----BEGIN PGP SIGNED MESSAGE-----'. "                                                                                     |
+| "data_after_sig"      | "Signed security.txt must not contain data after the signature."                                                                                                            |
+| "no_csaf_file"        | "All CSAF fields must point to a provider-metadata.json file."                                                                                                              |
+| "pgp_data_error"      | "Signed message did not contain a correct ASCII-armored PGP block."                                                                                                         |
+| "pgp_error"           | "Decoding or parsing of the pgp message failed."                                                                                                                            |
+| "bom_in_file"         | "The Byte-Order Mark was found at the start of the file. Security.txt must be encoded using UTF-8 in Net-Unicode form, the BOM signature must not appear at the beginning." |
 
 
 ### Possible recommendations

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ The package is available on pypi. It can be installed using pip:
 ## Usage
 
 ```python
-
 >>> from sectxt import SecurityTXT
 >>> s = SecurityTXT("www.example.com")
 >>> s.is_valid()
@@ -26,7 +25,6 @@ True
 ## Validation
 
 ```python
-
 >>> from sectxt import SecurityTXT
 >>> s = SecurityTXT("www.example.com")
 >>> s.errors
@@ -102,13 +100,22 @@ a dict with three keys:
 The scraper attempts to find the security.txt of the given domain in the correct location `/.well-known/security.txt`. It also looks in the old location and with unsecure `http` scheme which would result in validation errors. To prevent possible errors getting the file from the domain a user-agent is added to the header of the request. The user agent that is added is `Mozilla/5.0 (Windows NT 6.1; WOW64; rv:12.0) Gecko/20100101 Firefox/12.0`, which would mock a browser in firefox with a Windows 7 OS.
 If a security.txt file is found that file is than parsed. Any errors, recommendations or notifications that are found would be returned.
 
+### Test security.txt files locally
+
+It is possible to give a local path as the url parameter. For this behaviour you have to turn on the `is_local` parameter.
+Doing this will only validate the contents of the file given.
+
+```python
+>>> from sectxt import SecurityTXT
+>>> s = SecurityTXT("/home/example/security.txt", is_local=True)
+```
+
 ---
 
 [1] The security.txt parser will check for the addition of the digital signature, but it will not verify the validity of the signature.
 
-[2] Regarding code "unknown_field": According to RFC 9116 section 2.4, any fields that are not explicitly supported must be ignored. This parser does add a notification for unknown fields by default. This behaviour can be turned off using the parameter recommend_unknown_fields:
+[2] Regarding code "unknown_field": According to RFC 9116 section 2.4, any fields that are not explicitly supported must be ignored. This parser does add a notification for unknown fields by default. This behaviour can be turned off using the parameter `recommend_unknown_fields`:
 ```python
-
 >>> from sectxt import SecurityTXT
 >>> s = SecurityTXT("www.example.com", recommend_unknown_fields=False)
 ```

--- a/sectxt/__init__.py
+++ b/sectxt/__init__.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from typing import Optional, Union, List, DefaultDict
 from urllib.parse import urlsplit, urlunsplit
 import pgpy
+from dateutil.relativedelta import relativedelta
 from pgpy.errors import PGPError
 
 if sys.version_info < (3, 8):
@@ -22,7 +23,7 @@ else:
 import dateutil.parser
 import requests
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 
 s = requests.Session()
 
@@ -277,7 +278,7 @@ class Parser:
                 return
 
             now = datetime.now(timezone.utc)
-            max_value = now.replace(year=now.year + 1)
+            max_value = now + relativedelta(years=1)
             if date_value > max_value:
                 self._add_recommendation(
                     "long_expiry",

--- a/sectxt/__init__.py
+++ b/sectxt/__init__.py
@@ -421,12 +421,12 @@ class SecurityTXT(Parser):
         try:
             if content.startswith(codecs.BOM_UTF8):
                 content = content.replace(codecs.BOM_UTF8, b'')
-            self._add_error(
-                "bom_in_file",
-                "The Byte-Order Mark was found in the UTF-8 File. "
-                "Security.txt must be encoded using UTF-8 in Net-Unicode form, "
-                "the BOM signature must not appear at the beginning."
-            )
+                self._add_error(
+                    "bom_in_file",
+                    "The Byte-Order Mark was found at the start of the file. "
+                    "Security.txt must be encoded using UTF-8 in Net-Unicode form, "
+                    "the BOM signature must not appear at the beginning."
+                )
             return content.decode('utf-8')
         except UnicodeError:
             self._add_error("utf8", "Content must be utf-8 encoded.")

--- a/sectxt/__init__.py
+++ b/sectxt/__init__.py
@@ -422,7 +422,7 @@ class SecurityTXT(Parser):
     def _get_str(self, content: bytes) -> str:
         try:
             if content.startswith(codecs.BOM_UTF8):
-                content = content.replace(codecs.BOM_UTF8, b'')
+                content = content.replace(codecs.BOM_UTF8, b'', 1)
                 self._add_error(
                     "bom_in_file",
                     "The Byte-Order Mark was found at the start of the file. "

--- a/test/test_sectxt.py
+++ b/test/test_sectxt.py
@@ -7,6 +7,7 @@ from datetime import date, timedelta
 from unittest import TestCase
 from sectxt import Parser, SecurityTXT
 from requests_mock.mocker import Mocker
+import os
 
 _signed_example = f"""-----BEGIN PGP SIGNED MESSAGE-----
 Hash: SHA256
@@ -318,3 +319,19 @@ class SecTxtTestCase(TestCase):
             assert(not s.is_valid())
             if not any(d["code"] == "bom_in_file" for d in s.errors):
                 pytest.fail("bom_in_file error code should be given")
+
+    # noinspection PyMethodMayBeStatic
+    def test_local_file(self):
+        # Create a text file to be used for the local test
+        test_file_name = "test_security.txt"
+        f = open(test_file_name, "w")
+        f.write(_signed_example)
+        f.close()
+        cwd = os.getcwd()
+        test_file_path = os.path.join(cwd, test_file_name)
+        s = SecurityTXT(test_file_path, is_local=True)
+        assert (s.is_valid())
+
+        # Remove the file after the test is done.
+        if os.path.exists(test_file_path):
+            os.remove(test_file_path)


### PR DESCRIPTION
A new version which solves an issue with the BOM error always showing even when not applicable and fixes an error that occures on leap days. This includes the following issues:
- #64 : It is now possible to test local files by adding the `is_local` flag to True and passing a local path as the url parameter. This will only validate the content of the file given
- #65 : The BOM error was always shown even when not applicable. This issue has been fixed and the error message is improved.
- #66 : On leap days the validation check would fail because it would check for a year later. This was not done correctly and it would fail. This is fixed now.