### PR TITLE
Require PGPy pull request 467

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ python-dateutil==2.9.0.post0
 langcodes==3.3.0
 pytest==8.1.1
 requests-mock==1.12.1
-PGPy==0.6.0
+PGPy @ https://github.com/SecurityInnovation/PGPy/archive/09014c72b4557dd1254cf68a32e50f78515f5f32.zip


### PR DESCRIPTION
- Fixes #74.
- Of course the ideal situation is that https://github.com/SecurityInnovation/PGPy/pull/467 get's merged and released as 0.6.1, for now maybe reference the PR?