### PR TITLE
Feature/redirect check

### DIFF
--- a/sectxt/__init__.py
+++ b/sectxt/__init__.py
@@ -575,6 +575,9 @@ class SecurityTXT(Parser):
                     except:
                         continue
                     if resp.status_code == 200:
+                        if resp.history:
+                            if not resp.url.endswith(path):
+                                continue
                         self._path = path
                         self._url = url
                         if scheme != "https":

--- a/test/test_sectxt.py
+++ b/test/test_sectxt.py
@@ -361,3 +361,14 @@ class SecTxtTestCase(TestCase):
         # Remove the file after the test is done.
         if os.path.exists(test_file_path):
             os.remove(test_file_path)
+
+    def test_quick(self):
+        print("Test")
+        url = "aua24ag.de"
+        s = SecurityTXT(url)
+        print(s.errors)
+        print(s.recommendations)
+        print(s.notifications)
+        print(s.is_valid())
+
+

--- a/test/test_sectxt.py
+++ b/test/test_sectxt.py
@@ -361,14 +361,3 @@ class SecTxtTestCase(TestCase):
         # Remove the file after the test is done.
         if os.path.exists(test_file_path):
             os.remove(test_file_path)
-
-    def test_quick(self):
-        print("Test")
-        url = "aua24ag.de"
-        s = SecurityTXT(url)
-        print(s.errors)
-        print(s.recommendations)
-        print(s.notifications)
-        print(s.is_valid())
-
-


### PR DESCRIPTION
pull request to resolve issue #72 Invalid responses are not handled properly

When it checks the security.txt it's possible that the domain has a redirect configured for that url. This is allowed by the [RFC](https://www.rfc-editor.org/rfc/rfc9116#name-location-of-the-securitytxt). But the path should remain unchanged, if the redirects points to a different path with a valid security.txt it should still log the error that the security.txt was not found at the correct location. We add a check to see if a redirect has occured and if that is the case that the path remains the same.